### PR TITLE
Ensure useCase.description is rendered with the correct body font size

### DIFF
--- a/src/molecules/consent-section/consent-section-info.molecule.tsx
+++ b/src/molecules/consent-section/consent-section-info.molecule.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box } from '@mui/material';
+import {Box, Typography} from '@mui/material';
 import { UseCaseResponse } from '../../generated/consent/api';
 import { Accordion } from '../../atoms/accordion/accordion.molecule';
 import { GeneralInformation } from '../../atoms/info-accordions/general-info.atom';
@@ -37,7 +37,7 @@ export const ConsentSectionInfo: React.FC<ConsentSectionInfoProps> = (props) => 
     <>
       <Box sx={{ mb: 4, position: 'relative' }}>
         <GeneralInformation hideDuplicateListItem={getHideDuplicates()} />
-        <Accordion title="What is the purpose of accessing my data?" content={useCase.description} />
+        <Accordion title="What is the purpose of accessing my data?" content={<Typography variant="body1">{useCase.description}</Typography>} />
         {dataHandlers && dataHandlers.length > 0 && <DataHandlingInfo dataHandlers={dataHandlers} />}
         {useCase.osps && useCase.osps.length > 0 && (
           <SupportingParties title={'Supporting Parties'} useCase={useCase} outsourcedServiceProviders={useCase.osps} />


### PR DESCRIPTION
The useCase.description string is passed directly to the AccordianDetails which renders out as a div without a fontSize specified.  This results in the default 10px height being shown (due to the 10px simplification method this library employs).

Wrapping in Typography providers a cleaner way to handle rendering the string.